### PR TITLE
Add automated testing to module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ php:
  - 7.0
  - 7.1
 
+addons:
+  postgresql: 9.3
+
 matrix:
   allow_failures:
     - env: DB=pgsql MOODLE_BRANCH=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ php:
 addons:
   postgresql: 9.3
 
-matrix:
-  allow_failures:
-    - env: DB=pgsql MOODLE_BRANCH=master
-    - env: DB=mysqli MOODLE_BRANCH=master
+#matrix:
+#  allow_failures:
+#    - env: DB=pgsql MOODLE_BRANCH=master
+#    - env: DB=mysqli MOODLE_BRANCH=master
 
 env:
  global:

--- a/classes/groups.php
+++ b/classes/groups.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace mod_groupmembers;
+defined('MOODLE_INTERNAL') || die();
 
 /**
  * Static methods for collecting relevant groups and members

--- a/classes/groups.php
+++ b/classes/groups.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of a plugin for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_groupmembers;
+
+/**
+ * Static methods for collecting relevant groups and members
+ *
+ * @group    mod_groupmembers
+ * @package    mod_groupmembers
+ * @copyright  2017 Dennis M. Riehle, WWU Münster
+ * @copyright  2017 Jan C. Dageförde, WWU Münster
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class groups {
+    /**
+     * Fetch the relevant groups and members. Note that this function does not access module instance
+     * settings itself; instead, you are expected to pass relevant settings (esp. Grouping ID and whether only own
+     * groups should be displayed) yourself.
+     *
+     * @param int $courseid ID of the course
+     * @param int $groupingid ID of the grouping (0 if irrelevant)
+     * @param int $userid ID of the current user
+     * @param bool $onlyown Whether only groups of the given user $userid should be returned
+     * @return array Numerically-indexed array of all relevant groups. Each element is an array of the form [
+     *      'group' => \stdClass, 'members' => array[\stdClass], 'ismember' => bool ]
+     */
+    public static function get_groups_and_members($courseid, $groupingid, $userid, $onlyown) {
+        $groupsandmembers = array();
+
+        // Fetch relevant groups.
+        if ($onlyown) {
+            $groups = groups_get_all_groups($courseid, $userid, $groupingid);
+        } else {
+            $groups = groups_get_all_groups($courseid, 0, $groupingid);
+        }
+
+        foreach ($groups as $group) {
+            // Check whether current user is a member. If only own groups are displayed, this check is trivial.
+            if ($onlyown) {
+                $ismember = true;
+            } else {
+                $ismember = groups_is_member($group->id, $userid);
+            }
+
+            // Get members of group.
+            $members = groups_get_members($group->id);
+            $groupsandmembers[] = array(
+                'group' => $group,
+                'members' => $members,
+                'ismember' => $ismember
+            );
+        }
+
+        return $groupsandmembers;
+    }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,12 @@
 fixes:
-	- "moodle/mod/groupmembers/::"
+  - "moodle/mod/groupmembers/::"
+
+ignore:
+  # artificial/Moodle API files
+  - "tests/**/*"
+  - "lang/**/*"
+  - "db/**/*"
+  - "version.php"
+  # entry points (consider Behat instead)
+  - "index.php"
+  - "view.php"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,9 @@ ignore:
   - "tests/**/*"
   - "lang/**/*"
   - "db/**/*"
+  - "db/.*"
   - "version.php"
   # entry points (consider Behat instead)
   - "index.php"
   - "view.php"
+  - "mod_form.php"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+	- "moodle/mod/groupmembers/::"

--- a/renderer.php
+++ b/renderer.php
@@ -73,6 +73,7 @@ class mod_groupmembers_renderer extends plugin_renderer_base {
                 'id' => $group['group']->id,
                 'name' => $group['group']->name,
                 'members' => $members,
+                'ismember' => $group['ismember']
             );
         }
         return $this->render_from_template('mod_groupmembers/allgroups', $data);

--- a/templates/allgroups.mustache
+++ b/templates/allgroups.mustache
@@ -21,8 +21,8 @@
 
 }}
 {{#groups}}
-<h3 id="groupmembers-group-{{id}}">{{name}}</h3>
-<table class="generaltable">
+<h3 id="groupmembers-group-{{id}}"{{#ismember}} class="ismember"{{/ismember}}>{{name}}</h3>
+<table class="generaltable{{#ismember}} ismember{{/ismember}}" id="groupmembers-group-{{id}}-members">
     <thead>
     <tr>
         <th style="width: 50%">{{#str}}user:fullname, mod_groupmembers{{/str}}</th>

--- a/tests/groups_datastructure_test.php
+++ b/tests/groups_datastructure_test.php
@@ -1,0 +1,106 @@
+<?php
+// This file is part of a plugin for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Test logic used by the renderer whether to show/hide particular elements
+ *
+ * @group    mod_groupmembers
+ * @package    mod_groupmembers
+ * @copyright  2017 Dennis M. Riehle, WWU Münster
+ * @copyright  2017 Jan C. Dageförde, WWU Münster
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
+
+    public function test_only_own_nogrouping() {
+        $this->resetAfterTest();
+        //create course
+        //create users
+        //create enrolments
+        //create groups
+
+        //call .\groups::get_groups_and_members (no grouping), assert empty
+
+        //add user to group
+
+        //call .\groups::get_groups_and_members (no grouping), assert 1 group
+
+        //assertTrue ismember on single group
+
+
+        $this->assertTrue(true);
+    }
+
+    public function test_only_own_withgrouping() {
+        $this->resetAfterTest();
+        //create course
+        //create users
+        //create enrolments
+        //create groups
+
+        //call .\groups::get_groups_and_members (with grouping), assert empty
+
+        //add user to group
+
+        //call .\groups::get_groups_and_members (with grouping), assert empty
+
+        //add group to grouping
+
+        //call .\groups::get_groups_and_members (with grouping), assert 1 group
+
+        //assertTrue ismember on single group
+
+        $this->assertTrue(true);
+    }
+    public function test_all_nogrouping() {
+        $this->resetAfterTest();
+        //create course
+        //create users
+        //create enrolments
+        //create groups
+
+        //call .\groups::get_groups_and_members (no grouping), assert all groups
+        //assertFalse ismember on all groups
+
+        //add user to group
+
+        //call .\groups::get_groups_and_members (no grouping), assert all groups
+        //assertTrue ismember on 1 groups
+        $this->assertTrue(false);
+    }
+
+    public function test_all_withgrouping() {
+        $this->resetAfterTest();
+        //create course
+        //create users
+        //create enrolments
+        //create groups
+
+        //call .\groups::get_groups_and_members (with grouping), assert empty
+
+        //add group to grouping
+
+        //call .\groups::get_groups_and_members (with grouping), assert 1 group
+        //assertFalse ismember
+
+        //add user to group
+
+        //call .\groups::get_groups_and_members (no grouping), assert 1 group
+        //assertTrue ismember
+
+        $this->assertTrue(false);
+    }
+}

--- a/tests/groups_datastructure_test.php
+++ b/tests/groups_datastructure_test.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
  * Test logic used by the renderer whether to show/hide particular elements
  *
@@ -150,8 +152,6 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
      * - limit to particular grouping
      */
     public function test_all_withgrouping() {
-
-
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
 
@@ -176,7 +176,7 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
 
         static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($course->id, $grouping2->id, $user1->id, false));
 
-        // Add group to grouping
+        // Add group to grouping.
         $dg->create_grouping_group(['groupingid' => $grouping2->id, 'groupid' => $group3->id]);
         $dg->create_grouping_group(['groupingid' => $grouping2->id, 'groupid' => $group4->id]);
 

--- a/tests/groups_datastructure_test.php
+++ b/tests/groups_datastructure_test.php
@@ -35,7 +35,7 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
 
-        list($userid, $courseid, $groupid) = static::prepare_nogrouping($dg);
+        list($courseid, $userid, $groupid) = static::prepare_nogrouping($dg);
 
         static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($courseid, 0, $userid, true));
 
@@ -55,34 +55,20 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
     public function test_only_own_withgrouping() {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
+        list($courseid, $userid, $groupid, $groupingid) = $this->prepare_nogrouping($dg);
 
-        // Create course.
-        $course = $dg->create_course();
+        $grouping2 = $dg->create_grouping(['courseid' => $courseid]);
 
-        // Create users and enrol.
-        $user1 = $dg->create_user();
-        $user2 = $dg->create_user();
-        $dg->enrol_user($user1->id, $course->id);
-        $dg->enrol_user($user2->id, $course->id);
-
-        // Create groups and groupings.
-        $group1 = $dg->create_group(['courseid' => $course->id]);
-        $group2 = $dg->create_group(['courseid' => $course->id]);
-        $grouping1 = $dg->create_grouping(['courseid' => $course->id]);
-        $grouping2 = $dg->create_grouping(['courseid' => $course->id]);
-        $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group1->id]);
-        $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group2->id]);
-
-        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($course->id, $grouping1->id, $user1->id, true));
-        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($course->id, $grouping2->id, $user1->id, true));
+        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($courseid, $groupingid, $userid, true));
+        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($courseid, $grouping2->id, $userid, true));
 
         // Add user to group.
-        $dg->create_group_member(['userid' => $user1->id, 'groupid' => $group1->id]);
+        $dg->create_group_member(['userid' => $userid, 'groupid' => $groupid]);
 
-        $result = \mod_groupmembers\groups::get_groups_and_members($course->id, $grouping1->id, $user1->id, true);
+        $result = \mod_groupmembers\groups::get_groups_and_members($courseid, $groupingid, $userid, true);
         static::assertCount(1, $result);
         static::assertTrue($result[0]['ismember']);
-        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($course->id, $grouping2->id, $user1->id, true));
+        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($courseid, $grouping2->id, $userid, true));
     }
 
     /**
@@ -93,7 +79,7 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
     public function test_all_nogrouping() {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
-        list($userid, $courseid, $groupid) = $this->prepare_nogrouping($dg);
+        list($courseid, $userid, $groupid) = $this->prepare_nogrouping($dg);
 
         $res1 = \mod_groupmembers\groups::get_groups_and_members($courseid, 0, $userid, false);
         static::assertCount(2, $res1);
@@ -187,6 +173,6 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
         $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group1->id]);
         $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group2->id]);
 
-        return [$course->id, $user1->id, $group1->id];
+        return [$course->id, $user1->id, $group1->id, $grouping1->id];
     }
 }

--- a/tests/groups_datastructure_test.php
+++ b/tests/groups_datastructure_test.php
@@ -35,7 +35,7 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
 
-        list($courseid, $userid, $groupid) = static::prepare_nogrouping($dg);
+        list($courseid, $userid, $groupid) = static::prepare_basic_data($dg);
 
         static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($courseid, 0, $userid, true));
 
@@ -55,7 +55,7 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
     public function test_only_own_withgrouping() {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
-        list($courseid, $userid, $groupid, $groupingid) = $this->prepare_nogrouping($dg);
+        list($courseid, $userid, $groupid, $groupingid) = $this->prepare_basic_data($dg);
 
         $grouping2 = $dg->create_grouping(['courseid' => $courseid]);
 
@@ -79,7 +79,7 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
     public function test_all_nogrouping() {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
-        list($courseid, $userid, $groupid) = $this->prepare_nogrouping($dg);
+        list($courseid, $userid, $groupid) = $this->prepare_basic_data($dg);
 
         $res1 = \mod_groupmembers\groups::get_groups_and_members($courseid, 0, $userid, false);
         static::assertCount(2, $res1);
@@ -110,42 +110,29 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
     public function test_all_withgrouping() {
         $this->resetAfterTest();
         $dg = static::getDataGenerator();
+        list($courseid, $userid) = $this->prepare_basic_data($dg);
 
-        // Create course.
-        $course = $dg->create_course();
+        // Create additional groups and groupings.
+        $group3 = $dg->create_group(['courseid' => $courseid]);
+        $group4 = $dg->create_group(['courseid' => $courseid]);
+        $grouping2 = $dg->create_grouping(['courseid' => $courseid]);
 
-        // Create users and enrol.
-        $user1 = $dg->create_user();
-        $user2 = $dg->create_user();
-        $dg->enrol_user($user1->id, $course->id);
-        $dg->enrol_user($user2->id, $course->id);
-
-        // Create groups and groupings.
-        $group1 = $dg->create_group(['courseid' => $course->id]);
-        $group2 = $dg->create_group(['courseid' => $course->id]);
-        $group3 = $dg->create_group(['courseid' => $course->id]);
-        $group4 = $dg->create_group(['courseid' => $course->id]);
-        $grouping1 = $dg->create_grouping(['courseid' => $course->id]);
-        $grouping2 = $dg->create_grouping(['courseid' => $course->id]);
-        $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group1->id]);
-        $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group2->id]);
-
-        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($course->id, $grouping2->id, $user1->id, false));
+        static::assertEmpty(\mod_groupmembers\groups::get_groups_and_members($courseid, $grouping2->id, $userid, false));
 
         // Add group to grouping.
         $dg->create_grouping_group(['groupingid' => $grouping2->id, 'groupid' => $group3->id]);
         $dg->create_grouping_group(['groupingid' => $grouping2->id, 'groupid' => $group4->id]);
 
-        $res1 = \mod_groupmembers\groups::get_groups_and_members($course->id, $grouping2->id, $user1->id, false);
+        $res1 = \mod_groupmembers\groups::get_groups_and_members($courseid, $grouping2->id, $userid, false);
         static::assertCount(2, $res1);
         foreach ($res1 as $group) {
             self::assertFalse($group['ismember']);
         }
 
         // Add user to group.
-        $dg->create_group_member(['userid' => $user1->id, 'groupid' => $group3->id]);
+        $dg->create_group_member(['userid' => $userid, 'groupid' => $group3->id]);
 
-        $res2 = \mod_groupmembers\groups::get_groups_and_members($course->id, $grouping2->id, $user1->id, false);
+        $res2 = \mod_groupmembers\groups::get_groups_and_members($courseid, $grouping2->id, $userid, false);
         static::assertCount(2, $res2);
         foreach ($res2 as $group) {
             if ($group['group']->id == $group3->id) {
@@ -156,7 +143,19 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
         }
     }
 
-    private static function prepare_nogrouping($dg) {
+    /**
+     * Prepares a general testing environment that is relevant for this test case, consisting of
+     * - 2 users, both enrolled in
+     * - 1 course, that contains
+     * - 1 grouping, which consists of
+     * - 2 groups.
+     *
+     * Users are not members of any groups.
+     *
+     * @param $dg testing_data_generator Data generator
+     * @return array [ID of course, ID of first user, ID of first group, ID of grouping]
+     */
+    private static function prepare_basic_data(testing_data_generator $dg) {
         // Create course.
         $course = $dg->create_course();
 
@@ -169,10 +168,10 @@ class mod_groupmembers_groups_datastructure_testcase extends advanced_testcase {
         // Create groups and groupings.
         $group1 = $dg->create_group(['courseid' => $course->id]);
         $group2 = $dg->create_group(['courseid' => $course->id]);
-        $grouping1 = $dg->create_grouping(['courseid' => $course->id]);
-        $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group1->id]);
-        $dg->create_grouping_group(['groupingid' => $grouping1->id, 'groupid' => $group2->id]);
+        $grouping = $dg->create_grouping(['courseid' => $course->id]);
+        $dg->create_grouping_group(['groupingid' => $grouping->id, 'groupid' => $group1->id]);
+        $dg->create_grouping_group(['groupingid' => $grouping->id, 'groupid' => $group2->id]);
 
-        return [$course->id, $user1->id, $group1->id, $grouping1->id];
+        return [$course->id, $user1->id, $group1->id, $grouping->id];
     }
 }

--- a/view.php
+++ b/view.php
@@ -53,6 +53,7 @@ $PAGE->set_heading($course->fullname);
 // Completion and trigger event.
 groupmembers_view($groupmembers, $course, $cm, $context);
 
+// Theme and module header/intro.
 echo $OUTPUT->header();
 echo $OUTPUT->heading(format_string($groupmembers->name), 2, null);
 
@@ -60,27 +61,12 @@ if (!empty($groupmembers->intro)) {
     echo $OUTPUT->box(format_module_intro('groupmembers', $groupmembers, $cm->id), 'generalbox', 'intro');
 }
 
-$groups = groups_get_all_groups($course->id, 0, $groupmembers->listgroupingid);
-
 // Collect applicable groups and their members.
-$groupsandmembers = array();
-foreach ($groups as $group) {
-    // Skip group, if user is not in the group and only own groups are to be displayed.
-    $ismember = groups_is_member($group->id, $USER->id);
-    if ($groupmembers->showgroups == GROUPMEMBERS_SHOWGROUPS_OWN && !$ismember) {
-        continue;
-    }
+$groupsandmembers = \mod_groupmembers\groups::get_groups_and_members($course->id, $groupmembers->listgroupingid,
+    $USER->id, $groupmembers->showgroups == GROUPMEMBERS_SHOWGROUPS_OWN);
 
-    // Get members of group.
-    $members = groups_get_members($group->id);
-    $groupsandmembers[] = array(
-        'group' => $group,
-        'members' => $members,
-        'ismember' => $ismember
-    );
-}
-
-if (count($groupsandmembers) == 0) {
+// Output special texts if no group was retrieved; otherwise render list.
+if (count($groupsandmembers) === 0) {
     if ($groupmembers->showgroups == GROUPMEMBERS_SHOWGROUPS_OWN) {
         echo $OUTPUT->box(get_string('noowngroupsavailable', 'groupmembers'));
     } else {
@@ -92,4 +78,5 @@ if (count($groupsandmembers) == 0) {
     echo $renderer->render_allgroups($groupsandmembers, $groupmembers->showemail);
 }
 
+// Theme footer.
 echo $OUTPUT->footer();


### PR DESCRIPTION
This adds PHPUnit tests to ensure that all intended groups are displayed to the user, and that _only_ those groups are displayed.

In the process, group retrieval/filtering logic was refactored away from the view and into a dedicated method.